### PR TITLE
Fix handling of empty types and identityref types

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -742,7 +742,7 @@ def test_xml_config(xml_safe_data_model, xml_safe_data):
     # convert InstanceValue to an XML-encoded string
     xml_obj = inst.to_xml()
     xml_text = ET.tostring(xml_obj).decode("utf-8")
-    #assert(xml_text == expected_xml_stripped) # fails, see Issue #87
+    assert(xml_text == expected_xml_stripped) # fails, see Issue #87
 
     # convert XML-encoded string back to an InstanceValue
     #parser = XMLParser(xml_text)

--- a/yangson/datatype.py
+++ b/yangson/datatype.py
@@ -263,7 +263,7 @@ class EmptyType(DataType):
         return [None]
 
     def from_xml(self: "EmptyType", xml: str) -> Optional[Tuple[None]]:
-        if xml == '':
+        if xml.text is None:
             return (None,)
 
     def to_xml(self: "EmptyType", val: Tuple[None]) -> None:

--- a/yangson/instance.py
+++ b/yangson/instance.py
@@ -554,7 +554,13 @@ class InstanceNode:
             # Array outside an Object doesn't make sense
             raise NotImplementedError
         else:
-            element.text = self.schema_node.type.to_xml(self.value)
+            sn = self.schema_node
+            if isinstance(sn.type, IdentityrefType) and sn.ns != self.value[1]:
+                module = self.schema_data.modules_by_name.get(self.value[1])
+                if not module:
+                    raise MissingModuleNamespace(sn.ns)
+                element.attrib['xmlns:'+self.value[1]] = module.xml_namespace
+            element.text = sn.type.to_xml(self.value)
 
         if elem is not None:
             return element
@@ -1339,6 +1345,8 @@ from .schemanode import (       # NOQA
             ChoiceNode, DataNode, InputNode,
             InternalNode, LeafNode, LeafListNode, ListNode,
             OutputNode, RpcActionNode, SequenceNode, TerminalNode)
-
             #AnyContentNode, CaseNode, DataNode, InternalNode,
             #LeafListNode, ListNode, RpcActionNode, SequenceNode)
+from .datatype import (
+            IdentityrefType
+)


### PR DESCRIPTION
Add explicit namespaces to XML representation for IdentityRef datatypes.
Also fixes a small bug for EmptyType which blocked the testcases.